### PR TITLE
Fix early stopping copy for torch engine

### DIFF
--- a/engines/torch_engine.py
+++ b/engines/torch_engine.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 from typing import List, Dict, Any
-from pathlib import Path
+import copy
 
 import numpy as np
 import torch
@@ -72,7 +72,7 @@ def _fit_single_model(X_train: np.ndarray, y_train: np.ndarray) -> Dict[str, Any
     crit = nn.BCELoss()
 
     best_val = float("inf")
-    best_state = None
+    best_state = copy.deepcopy(net.state_dict())
     patience_ctr = 0
     tloss, vloss = [], []
 
@@ -102,7 +102,7 @@ def _fit_single_model(X_train: np.ndarray, y_train: np.ndarray) -> Dict[str, Any
         # early stopping
         if vloss[-1] < best_val - 1e-6:
             best_val = vloss[-1]
-            best_state = net.state_dict()
+            best_state = copy.deepcopy(net.state_dict())
             patience_ctr = 0
         else:
             patience_ctr += 1


### PR DESCRIPTION
## Summary
- fix deep copy of best model state during torch training

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6855af0e0fd88330a7c2a22ecabd4c64