### PR TITLE
Improve ROC AUC handling

### DIFF
--- a/engines/sklearn_engine.py
+++ b/engines/sklearn_engine.py
@@ -101,6 +101,7 @@ def _evaluate_holdout(est, X_te, y_te):
         "test_accuracy": accuracy_score(y_te, preds),
         "test_f1_weighted": f1_score(y_te, preds, average="weighted"),
     }
+    n_classes = len(np.unique(y_te))
     if hasattr(est, "predict_proba"):
         y_score = est.predict_proba(X_te)
     elif hasattr(est, "decision_function"):
@@ -108,12 +109,13 @@ def _evaluate_holdout(est, X_te, y_te):
     else:
         y_score = None
     if y_score is not None:
-        if np.ndim(y_score) > 1 and y_score.shape[1] > 1:
+        if n_classes > 2:
             res["test_roc_auc"] = roc_auc_score(y_te, y_score, multi_class="ovr")
         else:
-            if np.ndim(y_score) > 1:
-                y_score = y_score[:, 1]
-            res["test_roc_auc"] = roc_auc_score(y_te, y_score)
+            score = y_score[:, 1] if np.ndim(y_score) > 1 else y_score
+            res["test_roc_auc"] = roc_auc_score(y_te, score)
+    else:
+        res["test_roc_auc"] = np.nan
     return res
 
 # ---------------------------------------------------------------------------

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,0 +1,38 @@
+import numpy as np
+from sklearn.datasets import make_classification
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+
+from engines.sklearn_engine import _evaluate_holdout
+
+
+def _check_basic_keys(res):
+    assert "test_accuracy" in res
+    assert "test_f1_weighted" in res
+    assert "test_roc_auc" in res
+
+
+def test_evaluate_holdout_binary():
+    X, y = make_classification(n_samples=50, n_features=5, n_classes=2, random_state=0)
+    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.2, random_state=0, stratify=y)
+    est = LogisticRegression(max_iter=1000).fit(X_tr, y_tr)
+    res = _evaluate_holdout(est, X_te, y_te)
+    _check_basic_keys(res)
+    assert isinstance(res["test_roc_auc"], float) or np.isnan(res["test_roc_auc"])
+
+
+def test_evaluate_holdout_multiclass():
+    X, y = make_classification(
+        n_samples=60,
+        n_features=5,
+        n_classes=3,
+        n_informative=4,
+        n_clusters_per_class=1,
+        random_state=0,
+    )
+    X_tr, X_te, y_tr, y_te = train_test_split(X, y, test_size=0.2, random_state=0, stratify=y)
+    est = LogisticRegression(max_iter=1000, multi_class="multinomial").fit(X_tr, y_tr)
+    res = _evaluate_holdout(est, X_te, y_te)
+    _check_basic_keys(res)
+    assert isinstance(res["test_roc_auc"], float) or np.isnan(res["test_roc_auc"])
+


### PR DESCRIPTION
## Summary
- compute number of classes in `_evaluate_holdout`
- use multiclass ROC AUC when needed
- always return `test_roc_auc`
- add unit tests for `_evaluate_holdout`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6855c227092c8330a94879b1d45e702c