### PR TITLE
Extend dataset loader

### DIFF
--- a/config.json
+++ b/config.json
@@ -68,9 +68,9 @@
   "torch_val_split": 0.2,
   "torch_cv_folds": 5,
 
-  "dataset_name": "breast_cancer",
-  "csv_path": null,
-  "parquet_path": null,
-  "url": null,
-  "target_col": null
+  "dataset_name": "iris",
+  "csv_path": "data/example.csv",
+  "parquet_path": "data/example.parquet",
+  "url": "https://example.com/data.csv",
+  "target_col": "target"
 }

--- a/config.py
+++ b/config.py
@@ -48,11 +48,11 @@ _DEFAULTS = {
     "torch_cv_folds": 5,
 
     # — dataset options —
-    #   breast_cancer | csv | parquet
+    #   breast_cancer | iris | wine | digits | csv | parquet | url_csv | url_parquet
     "dataset_name": "breast_cancer",
     "csv_path": None,
     "parquet_path": None,
-    "url": None,
+    "url": None,  # used when dataset_name is 'url_csv' or 'url_parquet'
     "target_col": None,
 }
 

--- a/data/loader.py
+++ b/data/loader.py
@@ -1,11 +1,13 @@
 """data/loader.py – centralized dataset access.
 
-Supports three modes controlled by ``settings.dataset_name``:
+Supports several modes controlled by ``settings.dataset_name``:
 
-* ``"breast_cancer"`` – scikit‑learn built‑in (default, no external files).
-* ``"csv"`` – load a user‑supplied CSV from ``settings.csv_path`` with
-  the target column given by ``settings.target_col``.
-* ``"parquet"`` – same as CSV but for Parquet files (auto‑detects dtypes).
+* names in ``SKLEARN_LOADERS`` (e.g. ``"breast_cancer"``, ``"iris"``, ``"wine"``)
+  which load scikit‑learn built‑in datasets (default requires no external files)
+* ``"csv"`` and ``"parquet"`` – load a local file from ``settings.csv_path`` /
+  ``settings.parquet_path`` with the target column given by ``settings.target_col``
+* ``"url_csv"`` and ``"url_parquet"`` – as above but download from
+  ``settings.url``
 
 Returns ``X, y`` as pandas objects so the rest of the pipeline remains
 unchanged.
@@ -13,17 +15,31 @@ unchanged.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Callable, Dict, Any
 import pandas as pd
-from sklearn.datasets import load_breast_cancer
+from sklearn.datasets import (
+    load_breast_cancer,
+    load_iris,
+    load_wine,
+    load_digits,
+)
 
 from config import settings
+
+# Mapping of available sklearn datasets
+SKLEARN_LOADERS: Dict[str, Callable[..., Any]] = {
+    "breast_cancer": load_breast_cancer,
+    "iris": load_iris,
+    "wine": load_wine,
+    "digits": load_digits,
+}
 
 __all__ = ["load_data"]
 
 
-def _load_breast_cancer() -> Tuple[pd.DataFrame, pd.Series]:
-    data = load_breast_cancer(as_frame=True)
+def _load_sklearn(name: str) -> Tuple[pd.DataFrame, pd.Series]:
+    loader = SKLEARN_LOADERS[name]
+    data = loader(as_frame=True)
     df = data.frame
     X = df.drop(columns="target")
     y = df["target"]
@@ -44,12 +60,26 @@ def _load_parquet(path: Path, target_col: str) -> Tuple[pd.DataFrame, pd.Series]
     return X, y
 
 
+def _load_url_csv(url: str, target_col: str) -> Tuple[pd.DataFrame, pd.Series]:
+    df = pd.read_csv(url)
+    y = df[target_col]
+    X = df.drop(columns=target_col)
+    return X, y
+
+
+def _load_url_parquet(url: str, target_col: str) -> Tuple[pd.DataFrame, pd.Series]:
+    df = pd.read_parquet(url)
+    y = df[target_col]
+    X = df.drop(columns=target_col)
+    return X, y
+
+
 def load_data() -> Tuple[pd.DataFrame, pd.Series]:
     """Return ``X, y`` based on the dataset specified in ``settings``."""
 
     name = settings.dataset_name.lower()
-    if name == "breast_cancer":
-        return _load_breast_cancer()
+    if name in SKLEARN_LOADERS:
+        return _load_sklearn(name)
 
     if name == "csv":
         if settings.csv_path is None or settings.target_col is None:
@@ -60,5 +90,15 @@ def load_data() -> Tuple[pd.DataFrame, pd.Series]:
         if settings.parquet_path is None or settings.target_col is None:
             raise ValueError("parquet_path and target_col must be set in Settings when dataset_name='parquet'.")
         return _load_parquet(Path(settings.parquet_path), settings.target_col)
+
+    if name == "url_csv":
+        if settings.url is None or settings.target_col is None:
+            raise ValueError("url and target_col must be set in Settings when dataset_name='url_csv'.")
+        return _load_url_csv(settings.url, settings.target_col)
+
+    if name == "url_parquet":
+        if settings.url is None or settings.target_col is None:
+            raise ValueError("url and target_col must be set in Settings when dataset_name='url_parquet'.")
+        return _load_url_parquet(settings.url, settings.target_col)
 
     raise ValueError(f"Unknown dataset_name '{settings.dataset_name}'.")

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,34 @@
+import pandas as pd
+from config import settings
+from data.loader import load_data
+
+
+def test_load_sklearn_iris(monkeypatch):
+    monkeypatch.setattr(settings, "dataset_name", "iris")
+    X, y = load_data()
+    assert not X.empty
+    assert len(X) == len(y)
+
+
+def test_load_url_csv(monkeypatch, tmp_path):
+    df = pd.DataFrame({"a": [1, 2], "target": [0, 1]})
+    csv_path = tmp_path / "data.csv"
+    df.to_csv(csv_path, index=False)
+    monkeypatch.setattr(settings, "dataset_name", "url_csv")
+    monkeypatch.setattr(settings, "url", str(csv_path))
+    monkeypatch.setattr(settings, "target_col", "target")
+    X, y = load_data()
+    assert list(X.columns) == ["a"]
+    assert y.tolist() == [0, 1]
+
+
+def test_load_url_parquet(monkeypatch, tmp_path):
+    df = pd.DataFrame({"b": [3, 4], "target": [1, 0]})
+    pq_path = tmp_path / "data.parquet"
+    df.to_parquet(pq_path)
+    monkeypatch.setattr(settings, "dataset_name", "url_parquet")
+    monkeypatch.setattr(settings, "url", str(pq_path))
+    monkeypatch.setattr(settings, "target_col", "target")
+    X, y = load_data()
+    assert list(X.columns) == ["b"]
+    assert y.tolist() == [1, 0]


### PR DESCRIPTION
## Summary
- extend dataset loader with sklearn dataset registry
- support loading datasets from URLs (CSV or Parquet)
- update config defaults and example config
- add tests for new loader paths

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6855d41556e08330a8468bc2bcdeb710