### PR TITLE
Remove stray execution in exploring module

### DIFF
--- a/data/exploring.py
+++ b/data/exploring.py
@@ -7,7 +7,6 @@ import os
 import re 
 import matplotlib.pyplot as plt
 
-
 def handle_missing_values(df,method = 'mean'):
     df_filled = df.copy()
 
@@ -61,7 +60,6 @@ def normalize_categorical(df, min_freq):
 
     return df_result
 
-
 def split_by_missing(df, custom_na):
     # Zamiana niestandardowych wartości na np.NaN
     df_clean = df.replace(custom_na, pd.NA)
@@ -85,10 +83,6 @@ def transfrom_the_df(df,na_cods = None,method='drop',min_freq=.01):
     df = normalize_categorical(df,min_freq)
 
     return(df)
-
-a = transfrom_the_df(df,na_cods=["?"])
-
-
 
 def explore_the_df(df,target):
     
@@ -117,7 +111,6 @@ def get_size(df):
     ncol = df.shape[1] # define number of columns 
     print(f'In data set you can find {ncol} columns and {nrow} rows')
     return(nrow,ncol)
-
 
 def summaries_strings(df,col_types):
 
@@ -205,8 +198,6 @@ def box_plots(df):
         plt.xlabel(col)
         plt.show()
 
-
-
 def check_nas(df):
     if ~( df.isnull().values.any()):
         print('No obviously missing values')
@@ -216,7 +207,6 @@ def check_nas(df):
         print('Percentage of missing values')
         print(percent_of_nas)
         return(percent_of_nas)
-
 
 def get_col_types(df):
 
@@ -228,8 +218,6 @@ def get_col_types(df):
         print(f'Data set contains following {i} columns')
         print(column_types[i])
     return(column_types)
-
-
 
 def explore_df_target(df, target_col):
     
@@ -264,7 +252,6 @@ def explore_df_target(df, target_col):
             plt.legend(title=target_col)
             plt.tight_layout()
             plt.show()
-
 
 def eksplore_regression(df, target_col):
     


### PR DESCRIPTION
## Summary
- prevent accidental execution in `data/exploring.py` by removing a line that called `transfrom_the_df` on import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6855d82ebd788330a4c5d8eb1c175499