### PR TITLE
Organize plots into model and EDA folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project contains a simple machine learning workflow with optional data expl
 The `data/exploring.py` module provides helper functions for inspecting a
 dataset (missing values, categorical normalisation, etc.). Running it will
 produce plots and a short text summary. The resulting HTML file is placed in the
-`plots` directory.
+`plots/eda` directory under the dataset-specific folder.
 
 Trigger the exploration report with:
 ```bash
@@ -34,13 +34,13 @@ metrics:
 ```bash
 python main.py
 ```
-Results are written under `plots/` along with an HTML report summarising
-scores and figures.
+Results are written under `plots/<dataset>/models` along with an HTML report
+summarising scores and figures.
 
 ## Generating reports
 
 After the pipeline finishes, an HTML report is created in
-`plots/report.html`. This report contains the metrics table and diagnostic
-figures for all models. If the exploration step was run beforehand, its report
-will also appear in the same folder.
+`plots/<dataset>/models/report.html`. This report contains the metrics table and
+diagnostic figures for all models. If the exploration step was run beforehand,
+its report appears in `plots/<dataset>/eda/`.
 

--- a/main.py
+++ b/main.py
@@ -33,7 +33,9 @@ from reports.report_generator import generate_report, generate_data_report
 
 def run_pipeline():
     # 1) guarantee plot directory exists ----------------------------
-    Path(settings.plot_dir).mkdir(parents=True, exist_ok=True)
+    base = Path(settings.plot_dir)
+    model_dir = base / "models"
+    model_dir.mkdir(parents=True, exist_ok=True)
     
     # 2) load data --------------------------------------------------
     X, y = load_data()                       # returns pandas objects
@@ -67,24 +69,26 @@ def run_pipeline():
     print("✓ Plots written:", fig_paths)
 
     metrics_df = pd.DataFrame(all_records)
-    csv_path = Path(settings.plot_dir) / "combined_model_results.csv"
+    csv_path = model_dir / "combined_model_results.csv"
     metrics_df.to_csv(csv_path, index=False)
     print(f"✓ Metrics saved to {csv_path.resolve()}")
 
-    generate_report(metrics_df, fig_paths, report_path=Path(settings.plot_dir) / "report.html")
+    generate_report(metrics_df, fig_paths, report_path=model_dir / "report.html")
 
     return metrics_df
 
 
 def run_exploration():
     """Run only the data exploration workflow."""
-    Path(settings.plot_dir).mkdir(parents=True, exist_ok=True)
+    base = Path(settings.plot_dir)
+    eda_dir = base / "eda"
+    eda_dir.mkdir(parents=True, exist_ok=True)
     X, y = load_data()
     target = settings.target_col or "target"
     df = X.copy()
     df[target] = y
     stats = run_data_exploration(df, target)
-    generate_data_report(stats, report_path=Path(settings.plot_dir) / "data_report.html")
+    generate_data_report(stats, report_path=eda_dir / "data_report.html")
     return stats
 
 

--- a/reports/data_report.py
+++ b/reports/data_report.py
@@ -42,10 +42,11 @@ def generate_data_report(
     plot_paths : dict
         Mapping of plot titles to saved image paths.
     report_path : str or Path, optional
-        Where to write the report. Defaults to ``plots/eda_report.html``.
+        Where to write the report. Defaults to
+        ``plots/<dataset>/eda/eda_report.html``.
     """
     if report_path is None:
-        report_path = Path(settings.plot_dir) / "eda_report.html"
+        report_path = Path(settings.plot_dir) / "eda" / "eda_report.html"
     else:
         report_path = Path(report_path)
 

--- a/reports/plots.py
+++ b/reports/plots.py
@@ -2,7 +2,7 @@
 
 Generate diagnostic figures (confusion matrix, ROC curve, loss curve) for
 both scikit‑learn and Torch engines.  All plots are written to
-``settings.plot_dir`` and a nested dict of filepaths is returned so the
+``settings.plot_dir/models`` and a nested dict of filepaths is returned so the
 report layer can embed them.
 """
 from __future__ import annotations
@@ -99,7 +99,7 @@ def _plot_pca_variance(X, out_path: Path):
 
 def make_all_figures(records: List[Dict[str, Any]], X_test, y_test) -> Dict[str, Dict[str, str]]:
     """Create plots for every model record and return their paths."""
-    plot_dir = Path(config.settings.plot_dir)   # always fresh
+    plot_dir = Path(config.settings.plot_dir) / "models"  # always fresh
     plot_dir.mkdir(parents=True, exist_ok=True)
 
     out: Dict[str, Dict[str, str]] = {}

--- a/reports/report_generator.py
+++ b/reports/report_generator.py
@@ -49,12 +49,13 @@ def generate_report(
     fig_paths : dict
         Nested mapping from `make_all_figures()` → {model: {plot_type: path}}.
     report_path : str or Path
-        Where to write the HTML file.  Defaults to ``plots/report.html``.
+        Where to write the HTML file.  Defaults to
+        ``plots/<dataset>/models/report.html``.
     drop_cols : list[str], optional
         Extra columns to drop from the metrics table.
     """
     if report_path is None:
-        report_path = Path(settings.plot_dir) / "report.html"
+        report_path = Path(settings.plot_dir) / "models" / "report.html"
     else:
         report_path = Path(report_path)
 
@@ -123,9 +124,18 @@ def generate_report(
 
 
 def generate_data_report(stats: Dict[str, Any], *, report_path: str | Path = None) -> Path:
-    """Generate a simple HTML report from ``run_data_exploration`` results."""
+    """Generate a simple HTML report from ``run_data_exploration`` results.
+
+    Parameters
+    ----------
+    stats : dict
+        Mapping of collected statistics to values.
+    report_path : str or Path, optional
+        Where to write the HTML file. Defaults to
+        ``plots/<dataset>/eda/data_report.html``.
+    """
     if report_path is None:
-        report_path = Path(settings.plot_dir) / "data_report.html"
+        report_path = Path(settings.plot_dir) / "eda" / "data_report.html"
     else:
         report_path = Path(report_path)
 


### PR DESCRIPTION
## Summary
- place model outputs under `plots/<dataset>/models`
- place EDA outputs under `plots/<dataset>/eda`
- update docstrings and README with new locations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6855dbd63610833083c942ad21c1a08f