### PR TITLE
Add EDA outputs and html integration

### DIFF
--- a/reports/eda_report_generator.py
+++ b/reports/eda_report_generator.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import List
+
+import pandas as pd
+from config import settings
+
+
+def _inline_png(path: Path, width: str = "420px") -> str:
+    """Return an <img> tag embedding the PNG as base64."""
+    with open(path, "rb") as fh:
+        enc = base64.b64encode(fh.read()).decode()
+    return f'<img src="data:image/png;base64,{enc}" width="{width}" />'
+
+
+def generate_eda_report(
+    eda_dir: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> Path:
+    """Generate an HTML report from saved EDA outputs."""
+    if eda_dir is None:
+        eda_dir = Path(settings.plot_dir) / "eda"
+    else:
+        eda_dir = Path(eda_dir)
+
+    if report_path is None:
+        report_path = eda_dir / "eda_report.html"
+    else:
+        report_path = Path(report_path)
+
+    imgs: List[str] = []
+    tables: List[str] = []
+    if eda_dir.exists():
+        for p in sorted(eda_dir.glob("*.png")):
+            imgs.append(_inline_png(p))
+        for csv in sorted(eda_dir.glob("*.csv")):
+            df_csv = pd.read_csv(csv)
+            table_html = df_csv.to_html(index=False, float_format="{:.3f}".format, border=0)
+            tables.append(f"<h3>{csv.name}</h3>{table_html}")
+
+    html = f"""
+    <html><head>
+        <style>
+            body  {{ font-family: Arial, sans-serif; margin: 20px; }}
+            table {{ border-collapse: collapse; margin-bottom: 20px; }}
+            table, th, td {{ border: 1px solid #ccc; padding: 4px; text-align: center; }}
+        </style>
+    </head><body>
+        <h1>EDA Report</h1>
+        {''.join(imgs)}
+        {''.join(tables)}
+    </body></html>
+    """
+
+    report_path.write_text(html, encoding="utf-8")
+    print(f"✓ EDA report written to {report_path.resolve()}")
+    return report_path
+
+
+if __name__ == "__main__":
+    generate_eda_report()

--- a/reports/eda_runner.py
+++ b/reports/eda_runner.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+import pandas as pd
+from config import settings
+from data.loader import load_data
+from data.exploring import explore_the_df
+
+
+def run_eda(eda_dir: str | Path | None = None) -> Path:
+    """Run exploratory data analysis and save outputs."""
+    if eda_dir is None:
+        eda_dir = Path(settings.plot_dir) / "eda"
+    else:
+        eda_dir = Path(eda_dir)
+
+    X, y = load_data()
+    df = pd.concat([X, y.rename("target")], axis=1)
+    explore_the_df(df, "target", eda_dir)
+    return eda_dir
+
+
+if __name__ == "__main__":
+    run_eda()


### PR DESCRIPTION
## Summary
- update EDA utilities to write plots/CSVs instead of showing
- add a small runner for EDA generation
- embed optional EDA section in HTML report
- add standalone `generate_eda_report` script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6855f7504ac48330aa8af04ebc9872e9