### PR TITLE
Add EDA report assets to runner and cleanup HTML generation

### DIFF
--- a/reports/eda_report_generator.py
+++ b/reports/eda_report_generator.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import List, Tuple
+
+import pandas as pd
+from config import settings
+
+__all__ = ["gather_eda_assets", "generate_eda_report"]
+
+
+def gather_eda_assets(eda_dir: str | Path | None = None) -> Tuple[List[str], List[str]]:
+    """Return lists of inline PNG tags and HTML tables stored in ``eda_dir``."""
+    if eda_dir is None:
+        eda_dir = Path(settings.plot_dir) / "eda"
+    else:
+        eda_dir = Path(eda_dir)
+
+    imgs: List[str] = []
+    tables: List[str] = []
+    if eda_dir.exists():
+        for p in sorted(eda_dir.glob("*.png")):
+            imgs.append(_inline_png(p))
+        for csv in sorted(eda_dir.glob("*.csv")):
+            df_csv = pd.read_csv(csv)
+            table_html = df_csv.to_html(index=False, float_format="{:.3f}".format, border=0)
+            tables.append(f"<h3>{csv.name}</h3>{table_html}")
+
+    return imgs, tables
+
+
+def _inline_png(path: Path, width: str = "420px") -> str:
+    """Return an <img> tag embedding the PNG as base64."""
+    with open(path, "rb") as fh:
+        enc = base64.b64encode(fh.read()).decode()
+    return f'<img src="data:image/png;base64,{enc}" width="{width}" />'
+
+
+def generate_eda_report(
+    eda_dir: str | Path | None = None,
+    report_path: str | Path | None = None,
+) -> Path:
+    """Generate an HTML report from saved EDA outputs."""
+    if eda_dir is None:
+        eda_dir = Path(settings.plot_dir) / "eda"
+    else:
+        eda_dir = Path(eda_dir)
+
+    if report_path is None:
+        report_path = eda_dir / "eda_report.html"
+    else:
+        report_path = Path(report_path)
+
+    imgs, tables = gather_eda_assets(eda_dir)
+
+    html = f"""
+    <html><head>
+        <style>
+            body  {{ font-family: Arial, sans-serif; margin: 20px; }}
+            table {{ border-collapse: collapse; margin-bottom: 20px; }}
+            table, th, td {{ border: 1px solid #ccc; padding: 4px; text-align: center; }}
+        </style>
+    </head><body>
+        <h1>EDA Report</h1>
+        {''.join(imgs)}
+        {''.join(tables)}
+    </body></html>
+    """
+
+    report_path.write_text(html, encoding="utf-8")
+    print(f"✓ EDA report written to {report_path.resolve()}")
+    return report_path
+
+
+if __name__ == "__main__":
+    generate_eda_report()

--- a/reports/eda_runner.py
+++ b/reports/eda_runner.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pandas as pd
+from config import settings
+from data.loader import load_data
+from data.exploring import explore_the_df, eksplore_regression
+from .eda_report_generator import generate_eda_report
+
+
+def run_eda(eda_dir: str | Path | None = None) -> Path:
+    """Run exploratory data analysis and save outputs."""
+    if eda_dir is None:
+        eda_dir = Path(settings.plot_dir) / "eda"
+    else:
+        eda_dir = Path(eda_dir)
+
+    X, y = load_data()
+    df = pd.concat([X, y.rename("target")], axis=1)
+    explore_the_df(df, "target", eda_dir)
+
+    # optional regression-style plots if target is numeric
+    if pd.api.types.is_numeric_dtype(df["target"]):
+        eksplore_regression(df, "target", eda_dir)
+
+    generate_eda_report(eda_dir)
+    return eda_dir
+
+
+if __name__ == "__main__":
+    run_eda()

--- a/reports/report_generator.py
+++ b/reports/report_generator.py
@@ -14,6 +14,7 @@ from typing import Dict, List
 
 import pandas as pd
 from config import settings
+from .eda_report_generator import gather_eda_assets
 
 
 # ---------------------------------------------------------------------------
@@ -37,6 +38,7 @@ def generate_report(
     *,
     report_path: str | Path = None,
     drop_cols: List[str] | None = None,
+    eda_dir: str | Path | None = None,
 ) -> Path:
     """Generate a self‑contained HTML report.
 
@@ -55,6 +57,11 @@ def generate_report(
         report_path = Path(settings.plot_dir) / "report.html"
     else:
         report_path = Path(report_path)
+
+    if eda_dir is None:
+        eda_dir = Path(settings.plot_dir) / "eda"
+    else:
+        eda_dir = Path(eda_dir)
 
     # ---- tidy metrics table ---------------------------------------
     non_scalar_cols = {
@@ -95,6 +102,12 @@ def generate_report(
         imgs = "<br/>".join(_inline_png(Path(p)) for p in paths.values())
         fig_rows.append(f"<tr><td><b>{model}</b></td><td>{imgs}</td></tr>")
 
+    # ---- EDA assets -----------------------------------------------
+    eda_imgs, eda_tables = gather_eda_assets(eda_dir)
+    eda_html = ""
+    if eda_imgs or eda_tables:
+        eda_html = "<h2>EDA</h2>" + "".join(eda_imgs) + "".join(eda_tables)
+
     # ---- assemble HTML --------------------------------------------
     html = f"""
     <html><head>
@@ -112,6 +125,7 @@ def generate_report(
         {metrics_html}
         <h2>Figures</h2>
         <table border="0">{''.join(fig_rows)}</table>
+        {eda_html}
     </body></html>
     """
 


### PR DESCRIPTION
## Summary
- share helper to gather saved EDA plots/tables
- generate a separate EDA report when running `eda_runner`
- call regression exploration when the target is numeric
- embed the EDA section in the main HTML report only when available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6855f7504ac48330aa8af04ebc9872e9